### PR TITLE
Remove modules from composer that were not introduced in this recipe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,8 @@
   ],
   "require": {
       "drupal/address": "*",
-      "drupal/access_unpublished": "*",
       "drupal/calendar_view": "*",
-      "drupal/field_group": "*",
-      "drupal/pathauto": "*",
-      "drupal/publication_date": "^2.0@beta",
-      "drupal/scheduler": "*",
-      "drupal/scheduler_content_moderation_integration": "^2.0@beta",
-      "drupal/simple_sitemap": "*",
       "drupal/smart_date": "*",
-      "drupal/token_or": "*",
       "kanopi/saplings-content-base": "*",
       "kanopi/saplings-content-types": "*"
   }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "kanopi/saplings-events",
-  "description": "Configuration for Saplings Events.",
+  "description": "Configuration for Saplings Events",
   "type": "drupal-recipe",
   "license": "GPL-2.0-or-later",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
       "drupal/address": "*",
       "drupal/calendar_view": "*",
       "drupal/smart_date": "*",
-      "kanopi/saplings-content-base": "*",
       "kanopi/saplings-content-types": "*"
   }
 }

--- a/recipe.yml
+++ b/recipe.yml
@@ -2,7 +2,6 @@ name: 'Saplings - Events'
 description: 'Configuration for Saplings Events'
 type: 'Site'
 recipes:
-  - saplings-content-base
   - saplings-content-types
 install:
   # Contrib.


### PR DESCRIPTION
## Description
I tested this recipe on the current (first!) release. I got this error when attempting to apply:
`The configuration 'imagemagick.settings' exists already and does not match the recipe's configuration`

I think I need to remove the modules in the composer file that were not introduced in this recipe.

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
